### PR TITLE
Fix Python 3 compatibility.

### DIFF
--- a/genesis/genesis.py
+++ b/genesis/genesis.py
@@ -5,8 +5,12 @@ import json
 import os
 import re
 import sys
-import urlparse
 import uuid
+
+if sys.version_info < (3, ):
+    import urlparse
+else:
+    from urllib import parse as urlparse
 
 import requests
 import slumber

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==1.3.1
 requests==2.6.0
-slumber==0.6.2
+slumber==0.7.1

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     ],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[r for r in open('requirements.txt').read().split('\n') if r != '' and r[:2] != '-e'],
+    install_requires=(
+        "requests>=2.6.0",
+        "slumber>=0.7.1",
+    ),
     test_suite='genesis.tests'
 )


### PR DESCRIPTION
* Use urllib.urlparse
* Require a newer version of slumber (>=0.7.1), with better Python 3
  compatibility
* Also explicitly list the install requirements in setup.py (using a
  soft version constraint).